### PR TITLE
allow use outside of CommonJS

### DIFF
--- a/src/Pikaday.js
+++ b/src/Pikaday.js
@@ -1,60 +1,71 @@
 /** @jsx React.DOM */
 
-var React = require('react');
-var Pikaday = require('pikaday');
-
-var ReactPikaday = React.createClass({
-
-  propTypes: {
-    value: React.PropTypes.instanceOf(Date),
-    onChange: React.PropTypes.func,
-
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.instanceOf(Date),
-      requestChange: React.PropTypes.func.isRequired
-    })
-  },
-
-  getValueLink: function(props) {
-    return props.valueLink || {
-      value: props.value,
-      requestChange: props.onChange
-    };
-  },
-
-  setDateIfChanged: function(newDate, prevDate) {
-    var newTime = newDate ? newDate.getTime() : null;
-    var prevTime = prevDate ? prevDate.getTime() : null;
-
-    if ( newTime !== prevTime ) {
-      this._picker.setDate(newDate, true);  // 2nd param = don't call onSelect
-    }
-  },
-
-  componentDidMount: function() {
-    var el = this.refs.pikaday.getDOMNode();
-
-    this._picker = new Pikaday({
-      field: el,
-      onSelect: this.getValueLink(this.props).requestChange
-    });
-
-    this.setDateIfChanged(this.getValueLink(this.props).value);
-  },
-
-  componentWillReceiveProps: function(nextProps) {
-    var newDate = this.getValueLink(nextProps).value;
-    var lastDate = this.getValueLink(this.props).value;
-
-    this.setDateIfChanged(newDate, lastDate);
-  },
-
-  render: function() {
-    return (
-      <input type="text" ref="pikaday" className={this.props.className}
-        placeholder={this.props.placeholder} />
-    );
+(function (root){
+  if (typeof require !== 'undefined') {
+    var React = require('react');
+    var Pikaday = require('pikaday');
   }
-});
 
-module.exports = ReactPikaday;
+  var ReactPikaday = React.createClass({
+
+    propTypes: {
+      value: React.PropTypes.instanceOf(Date),
+      onChange: React.PropTypes.func,
+
+      valueLink: React.PropTypes.shape({
+        value: React.PropTypes.instanceOf(Date),
+        requestChange: React.PropTypes.func.isRequired
+      })
+    },
+
+    getValueLink: function(props) {
+      return props.valueLink || {
+        value: props.value,
+        requestChange: props.onChange
+      };
+    },
+
+    setDateIfChanged: function(newDate, prevDate) {
+      var newTime = newDate ? newDate.getTime() : null;
+      var prevTime = prevDate ? prevDate.getTime() : null;
+
+      if ( newTime !== prevTime ) {
+        this._picker.setDate(newDate, true);  // 2nd param = don't call onSelect
+      }
+    },
+
+    componentDidMount: function() {
+      var el = this.refs.pikaday.getDOMNode();
+
+      this._picker = new Pikaday({
+        field: el,
+        onSelect: this.getValueLink(this.props).requestChange
+      });
+
+      this.setDateIfChanged(this.getValueLink(this.props).value);
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+      var newDate = this.getValueLink(nextProps).value;
+      var lastDate = this.getValueLink(this.props).value;
+
+      this.setDateIfChanged(newDate, lastDate);
+    },
+
+    render: function() {
+      return (
+        <input type="text" ref="pikaday" className={this.props.className}
+          placeholder={this.props.placeholder} />
+      );
+    }
+  });
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = ReactPikaday;
+  } else if (typeof define === 'function' && define.amd) {
+    define(function() { return ReactPikaday; });
+  } else {
+    root.ReactPikaday = ReactPikaday;
+  }
+
+}(this));

--- a/src/Pikaday.js
+++ b/src/Pikaday.js
@@ -1,71 +1,68 @@
 /** @jsx React.DOM */
 
 (function (root){
-  if (typeof require !== 'undefined') {
-    var React = require('react');
-    var Pikaday = require('pikaday');
-  }
+  function build(React, Pikaday){
+    var ReactPikaday = React.createClass({
 
-  var ReactPikaday = React.createClass({
-
-    propTypes: {
-      value: React.PropTypes.instanceOf(Date),
-      onChange: React.PropTypes.func,
-
-      valueLink: React.PropTypes.shape({
+      propTypes: {
         value: React.PropTypes.instanceOf(Date),
-        requestChange: React.PropTypes.func.isRequired
-      })
-    },
+        onChange: React.PropTypes.func,
 
-    getValueLink: function(props) {
-      return props.valueLink || {
-        value: props.value,
-        requestChange: props.onChange
-      };
-    },
+        valueLink: React.PropTypes.shape({
+          value: React.PropTypes.instanceOf(Date),
+          requestChange: React.PropTypes.func.isRequired
+        })
+      },
 
-    setDateIfChanged: function(newDate, prevDate) {
-      var newTime = newDate ? newDate.getTime() : null;
-      var prevTime = prevDate ? prevDate.getTime() : null;
+      getValueLink: function(props) {
+        return props.valueLink || {
+          value: props.value,
+          requestChange: props.onChange
+        };
+      },
 
-      if ( newTime !== prevTime ) {
-        this._picker.setDate(newDate, true);  // 2nd param = don't call onSelect
+      setDateIfChanged: function(newDate, prevDate) {
+        var newTime = newDate ? newDate.getTime() : null;
+        var prevTime = prevDate ? prevDate.getTime() : null;
+
+        if ( newTime !== prevTime ) {
+          this._picker.setDate(newDate, true);  // 2nd param = don't call onSelect
+        }
+      },
+
+      componentDidMount: function() {
+        var el = this.refs.pikaday.getDOMNode();
+
+        this._picker = new Pikaday({
+          field: el,
+          onSelect: this.getValueLink(this.props).requestChange
+        });
+
+        this.setDateIfChanged(this.getValueLink(this.props).value);
+      },
+
+      componentWillReceiveProps: function(nextProps) {
+        var newDate = this.getValueLink(nextProps).value;
+        var lastDate = this.getValueLink(this.props).value;
+
+        this.setDateIfChanged(newDate, lastDate);
+      },
+
+      render: function() {
+        return (
+          <input type="text" ref="pikaday" className={this.props.className}
+            placeholder={this.props.placeholder} />
+        );
       }
-    },
-
-    componentDidMount: function() {
-      var el = this.refs.pikaday.getDOMNode();
-
-      this._picker = new Pikaday({
-        field: el,
-        onSelect: this.getValueLink(this.props).requestChange
-      });
-
-      this.setDateIfChanged(this.getValueLink(this.props).value);
-    },
-
-    componentWillReceiveProps: function(nextProps) {
-      var newDate = this.getValueLink(nextProps).value;
-      var lastDate = this.getValueLink(this.props).value;
-
-      this.setDateIfChanged(newDate, lastDate);
-    },
-
-    render: function() {
-      return (
-        <input type="text" ref="pikaday" className={this.props.className}
-          placeholder={this.props.placeholder} />
-      );
-    }
-  });
+    });
+    return ReactPikaday;
+  };
 
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = ReactPikaday;
+    module.exports = build(require('react'), require('pikaday'));
   } else if (typeof define === 'function' && define.amd) {
-    define(function() { return ReactPikaday; });
+    define(['React', 'Pikaday'], build);
   } else {
-    root.ReactPikaday = ReactPikaday;
+    root.ReactPikaday = build(root.React, root.Pikaday);
   }
-
 }(this));


### PR DESCRIPTION
I'm working to integrate Pikaday into a React project that doesn't use CommonJS. Rather than re-invent the wheel, I figured to look for prior art, and this project best fit the bill, except that it assumes usage of commonJS. I've adapted the module to use a loader I've used elsewhere that works with AMD and vanilla browser JS as well.

The tests pass with some warnings akin to:

```
WARNING in ./~/React/lib/toArray.js
There is another module with an equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected.
```

I'm not familiar enough with Karma to pinpoint exactly where these are coming from, though I suspect it's the capitalized arguments to the build() function. If you can give me a pointer about those warnings I'd be happy to take a further stab at them, but in the meantime I have integration work to do.
