### PR TITLE
Browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
     "webpack": "^1.4.3",
     "webpack-dev-server": "^1.6.5"
   },
-
+  "browserify": {
+    "transform": [
+      "reactify"
+    ]
+  },
   "scripts": {
     "test": "scripts/test",
     "build-example": "scripts/build-example"


### PR DESCRIPTION
I tried to browserify a project that used react-pikaday, and found that the jsx was not being transformed. In order for module dependencies to be transformed, they need to specify the appropriate transformations in their package.json file.
