### PR TITLE
Fix example clear value button

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -56,7 +56,7 @@ var LinkedStateExample = React.createClass({
           The date is {formattedDate}
         </p>
         <p>
-          <Pikaday linkedValue={this.linkState('date')} />
+          <Pikaday valueLink={this.linkState('date')} />
         </p>
         <button onClick={() => { this.setState({date: null}); }}>
           Clear date

--- a/spec/main.js
+++ b/spec/main.js
@@ -110,4 +110,37 @@ describe('Pikaday', () => {
     });
 
   });
+
+  describe('clearing the value', () => {
+    it('works with LinkedStateMixin', function () {
+      var Form = React.createClass({
+        mixins: [ React.addons.LinkedStateMixin ],
+
+        getInitialState: function() {
+          return { date: new Date(2014, 0, 1) };
+        },
+
+        render: function() {
+          return (
+            <div>
+              <Pikaday ref="pikaday" valueLink={this.linkState('date')} />
+              <button ref="clearBtn"
+                onClick={() => this.setState({ date: null })}>
+                Clear
+              </button>
+            </div>
+          );
+        }
+      });
+
+      var component = React.renderComponent(<Form />, document.createElement('div'));
+
+      var input = TU.findRenderedDOMComponentWithTag(component, 'input').getDOMNode();
+      expect(input.value).to.be.eql('2014-01-01');
+
+      var clearBtn = component.refs.clearBtn.getDOMNode();
+      TU.Simulate.click(clearBtn);
+      expect(input.value).to.be.eql('');
+    });
+  });
 });


### PR DESCRIPTION
Closes #4

Seems like a simple typo in just the example code: `linkedValue` -> `valueLink`

Also, for fun, I added a test but it's useless because the test was
passing before.  The example just had a typo.

Your module is a great intro to creating a React component from a third party lib, thanks for putting it together.