### PR TITLE
Clear input value manually when newDate is falsey

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/Pikaday.js",
 
   "dependencies": {
-    "pikaday": "git://github.com/thomasboyt/pikaday#clear-field-on-falsy-setDate",
+    "pikaday": "^1.2.0",
     "react": "^0.11.2"
   },
   "devDependencies": {

--- a/src/Pikaday.js
+++ b/src/Pikaday.js
@@ -27,6 +27,10 @@ var ReactPikaday = React.createClass({
     var prevTime = prevDate ? prevDate.getTime() : null;
 
     if ( newTime !== prevTime ) {
+      if ( newDate === null ) {
+        // Workaround for pikaday not clearing value when date set to falsey
+        this.refs.pikaday.getDOMNode().value = '';
+      }
       this._picker.setDate(newDate, true);  // 2nd param = don't call onSelect
     }
   },


### PR DESCRIPTION
This change should let you switch back to using the original Pikaday
source instead of the custom fork as a dependency.