### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "description": "A React component wrapper around Pikaday.",
   "main": "src/Pikaday.js",
-
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/thomasboyt/react-pikaday.git"
+  },
   "dependencies": {
     "pikaday": "^1.2.0",
     "react": "^0.11.2"


### PR DESCRIPTION
This should make it easy to get from the npm page (which often shows up in search results) to the Github repo.