### PR TITLE
Published module now compiled JSX

### DIFF
--- a/dist/Pikaday.js
+++ b/dist/Pikaday.js
@@ -1,0 +1,62 @@
+var React = require('react');
+var Pikaday = require('pikaday');
+
+var ReactPikaday = React.createClass({displayName: "ReactPikaday",
+
+  propTypes: {
+    value: React.PropTypes.instanceOf(Date),
+    onChange: React.PropTypes.func,
+
+    valueLink: React.PropTypes.shape({
+      value: React.PropTypes.instanceOf(Date),
+      requestChange: React.PropTypes.func.isRequired
+    })
+  },
+
+  getValueLink: function(props) {
+    return props.valueLink || {
+      value: props.value,
+      requestChange: props.onChange
+    };
+  },
+
+  setDateIfChanged: function(newDate, prevDate) {
+    var newTime = newDate ? newDate.getTime() : null;
+    var prevTime = prevDate ? prevDate.getTime() : null;
+
+    if ( newTime !== prevTime ) {
+      if ( newDate === null ) {
+        // Workaround for pikaday not clearing value when date set to falsey
+        this.refs.pikaday.getDOMNode().value = '';
+      }
+      this._picker.setDate(newDate, true);  // 2nd param = don't call onSelect
+    }
+  },
+
+  componentDidMount: function() {
+    var el = this.refs.pikaday.getDOMNode();
+
+    this._picker = new Pikaday({
+      field: el,
+      onSelect: this.getValueLink(this.props).requestChange
+    });
+
+    this.setDateIfChanged(this.getValueLink(this.props).value);
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    var newDate = this.getValueLink(nextProps).value;
+    var lastDate = this.getValueLink(this.props).value;
+
+    this.setDateIfChanged(newDate, lastDate);
+  },
+
+  render: function() {
+    return (
+      React.createElement("input", {type: "text", ref: "pikaday", className: this.props.className, 
+        placeholder: this.props.placeholder, disabled: this.props.disabled})
+    );
+  }
+});
+
+module.exports = ReactPikaday;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "react-pikaday",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A React component wrapper around Pikaday.",
-  "main": "src/Pikaday.js",
+  "main": "dist/Pikaday.js",
   "repository": {
     "type": "git",
     "url": "http://github.com/thomasboyt/react-pikaday.git"
@@ -21,6 +21,7 @@
     "karma-mocha": "^0.1.9",
     "karma-webpack": "^1.2.2",
     "mocha": "^1.21.4",
+    "react-tools": "^0.13.2",
     "style-loader": "^0.8.0",
     "webpack": "^1.4.3",
     "webpack-dev-server": "^1.6.5"
@@ -32,9 +33,9 @@
   },
   "scripts": {
     "test": "scripts/test",
+    "build": "./node_modules/react-tools/bin/jsx --harmony src/Pikaday.js > dist/Pikaday.js",
     "build-example": "scripts/build-example"
   },
-
   "author": "Thomas Boyt <me@thomasboyt.com>",
   "license": "MIT"
 }


### PR DESCRIPTION
* use 'jsx --harmony' to compile (run `npm run build`)

I believe this follows the best practices with published React components in that the JavaScript that the `main` key of package.json points to is compiled JSX.