### PR TITLE
Pass all pikaday options in separate prop

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react", "es2015"]
+  "presets": ["react", "es2015", "stage-2"]
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-2": "^6.11.0",
     "chai": "^1.9.1",
     "css-loader": "^0.23.1",
     "eslint": "^3.2.2",

--- a/src/Pikaday.js
+++ b/src/Pikaday.js
@@ -6,11 +6,18 @@ var ReactPikaday = React.createClass({
   propTypes: {
     value: React.PropTypes.instanceOf(Date),
     onChange: React.PropTypes.func,
+    initialOptions: React.PropTypes.object,
 
     valueLink: React.PropTypes.shape({
       value: React.PropTypes.instanceOf(Date),
       requestChange: React.PropTypes.func.isRequired
     })
+  },
+
+  getDefaultProps: function() {
+    return {
+      initialOptions: {}
+    };
   },
 
   getValueLink: function(props) {
@@ -38,7 +45,8 @@ var ReactPikaday = React.createClass({
 
     this._picker = new Pikaday({
       field: el,
-      onSelect: this.getValueLink(this.props).requestChange
+      onSelect: this.getValueLink(this.props).requestChange,
+      ...this.props.initialOptions
     });
 
     this.setDateIfChanged(this.getValueLink(this.props).value);

--- a/src/__tests__/main.spec.js
+++ b/src/__tests__/main.spec.js
@@ -142,4 +142,22 @@ describe('Pikaday', () => {
       expect(input.value).to.be.eql('');
     });
   });
+
+  describe('pikaday options', () => {
+    it('passes options to pikaday plugin', function() {
+      var minDate = new Date(2014, 0, 1);
+      let result;
+      var Form = React.createClass({
+        render: function() {
+          return (
+            <Pikaday ref={({ _picker }) => result = _picker._o.minDate } initialOptions={{ minDate }}/>
+          );
+        }
+      });
+
+      TU.renderIntoDocument(<Form />);
+
+      expect(result).to.eql(minDate);
+    });
+  });
 });


### PR DESCRIPTION
Adds a `pikadayOptions` prop that is an object that is passed straight
to the Pikaday plugin. This allows users to configure pikaday however
they need to, while remaining flexible enough to not need updates when
pikaday changes.

Also adds `babel-preset-stage-2` to splat the pikadayOptions prop
without needing to do a merge.