### PR TITLE
allow passing arbitrary props to the input node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### master
+
+* Allow user to specify arbitrary props that will be passed on to the underlying <input> node (eg props: name, placeholder, data-*, ...)
+
 ### v0.4.1 (Apr 8 2016)
 
 * Allow React 15.x as a peer dependency

--- a/example/app.js
+++ b/example/app.js
@@ -26,7 +26,7 @@ var ManualExample = React.createClass({
           The date is {formattedDate}
         </p>
         <p>
-          <Pikaday value={date} onChange={this.handleChange} />
+          <Pikaday name="date" value={date} onChange={this.handleChange} />
         </p>
         <button onClick={() => {this.handleChange(null);}}>
           Clear date

--- a/src/Pikaday.js
+++ b/src/Pikaday.js
@@ -40,6 +40,17 @@ var ReactPikaday = React.createClass({
     }
   },
 
+  // user props to pass down to the underlying DOM node
+  getDomProps: function() {
+    var restProps = {};
+    for (var propKey in this.props) {
+      if (this.props.hasOwnProperty(propKey) && !ReactPikaday.propTypes[propKey]) {
+        restProps[propKey] = this.props[propKey];
+      }
+    }
+    return restProps
+  },
+
   componentDidMount: function() {
     var el = this.refs.pikaday;
 
@@ -61,8 +72,7 @@ var ReactPikaday = React.createClass({
 
   render: function() {
     return (
-      <input type="text" ref="pikaday" className={this.props.className}
-        placeholder={this.props.placeholder} disabled={this.props.disabled} />
+      <input type="text" ref="pikaday" {...this.getDomProps()} />
     );
   }
 });

--- a/src/__tests__/main.spec.js
+++ b/src/__tests__/main.spec.js
@@ -6,9 +6,11 @@ import TU from 'react-addons-test-utils';
 
 import Pikaday from '../Pikaday';
 
+const render = (reactEl) => ReactDOM.render(reactEl, document.createElement('div'));
+
 describe('Pikaday', () => {
   it('renders', () => {
-    var component = ReactDOM.render(<Pikaday />, document.createElement('div'));
+    var component = render(<Pikaday />);
     expect(component).to.be.ok;
   });
 
@@ -31,7 +33,7 @@ describe('Pikaday', () => {
         }
       });
 
-      var component = ReactDOM.render(<Form />, document.createElement('div'));
+      var component = render(<Form />);
       var pikaday = component.refs.pikaday._picker;
       pikaday.setDate(new Date(2014, 0, 1));
 
@@ -53,7 +55,7 @@ describe('Pikaday', () => {
         }
       });
 
-      var component = ReactDOM.render(<Form />, document.createElement('div'));
+      var component = render(<Form />);
       var pikaday = component.refs.pikaday._picker;
       pikaday.setDate(new Date(2014, 0, 1));
 
@@ -81,7 +83,7 @@ describe('Pikaday', () => {
         }
       });
 
-      var component = ReactDOM.render(<Form />, document.createElement('div'));
+      var component = render(<Form />);
 
       var input = TU.findRenderedDOMComponentWithTag(component, 'input');
       expect(input.value).to.be.eql('2014-01-01');
@@ -102,7 +104,7 @@ describe('Pikaday', () => {
         }
       });
 
-      var component = ReactDOM.render(<Form />, document.createElement('div'));
+      var component = render(<Form />);
 
       var input = TU.findRenderedDOMComponentWithTag(component, 'input');
       expect(input.value).to.be.eql('2014-01-01');
@@ -132,7 +134,7 @@ describe('Pikaday', () => {
         }
       });
 
-      var component = ReactDOM.render(<Form />, document.createElement('div'));
+      var component = render(<Form />);
 
       var input = TU.findRenderedDOMComponentWithTag(component, 'input');
       expect(input.value).to.be.eql('2014-01-01');
@@ -159,5 +161,13 @@ describe('Pikaday', () => {
 
       expect(result).to.eql(minDate);
     });
+  });
+
+  it('passes arbitrary, unexpected props to the input node', () => {
+    var component = render(<Pikaday name="foo" initialOptions={{foo: 'bar'}} />);
+    var input = TU.findRenderedDOMComponentWithTag(component, 'input');
+
+    expect(input.initialOptions).to.be.undefined
+    expect(input.name).to.eql('foo')
   });
 });


### PR DESCRIPTION
Allows passing any prop that isn't expected in the `propTypes`, to the underlying `<input>`

My use-case: pass the `name` prop to the `<input>`: `<Pickaday name="myDate" />`
